### PR TITLE
Feedback

### DIFF
--- a/feedback/defensive-colmeans-sol.Rmd
+++ b/feedback/defensive-colmeans-sol.Rmd
@@ -1,0 +1,71 @@
+```{r, child = "defensive-colmeans-ex.Rmd"}
+```
+
+----------------------------------------------------
+
+### Lösung:
+
+
+Minimalstlösung:
+```{r, col_means_def_1}
+# compute means of all numeric columns in <data>
+# input: a data.frame 
+# output: a data.frame containing the column means
+col_means <- function(data) {
+  stopifnot(is.data.frame(data), all(dim(data)) > 0)
+
+  numeric <- sapply(data, is.numeric)
+  data_numeric <- data[, numeric, drop = FALSE]
+
+  data.frame(vapply(data_numeric, mean, numeric(1)))
+}
+```
+```{r, col_means_test, error = TRUE}
+```
+
+Etwas ausgefeilter:
+```{r, col_means_def_2}
+# compute means of all columns in data for whose class "mean" is defined
+# data: anything that can be converted to a data.frame
+# na.rm: drop NAs?
+# output: a data.frame containing the column means of all numeric columns
+col_means <- function(data, na.rm = FALSE) {
+  checkmate::assert_flag(na.rm)
+  if (!is.data.frame(data)) {
+    data <- try(as.data.frame(data))
+    if (inherits(data, "try-error")) {
+      stop("<data> not convertable to a data.frame")
+    } else {
+      message("<data> converted to data.frame.")
+    }
+  }
+
+  # selecting columns for which mean can be computed:
+  use <- vapply(data, has_mean, logical(1))
+  # drop = FALSE so single columns work as expected!
+  data_numeric <- data[, use, drop = FALSE]
+  
+  # check for zero dims *after* selecting columns so all-character
+  # and all-factor data.frames get picked up as well.
+  if (any(dim(data_numeric) == 0)) {
+    rows_columns_zero <- as.character(c(10, 1) %*% (dim(data_numeric) == 0))
+    warning("<data> has zero ", 
+      switch(rows_columns_zero, 
+        "1"  = "columns", 
+        "10" = "rows", 
+        "11" = "rows and columns"), 
+      " for which a mean-method is defined")
+    return(data.frame())
+  }
+  
+  as.data.frame(lapply(data_numeric, mean, na.rm = na.rm))
+}
+# see methods("mean") for data types with mean-method
+has_mean <- function(x) {
+  is.numeric(x) |
+    inherits(x, what = c("Date", "POSIXct", "POSIXlt", "difftime"))
+}
+
+```
+```{r, col_means_test, error=TRUE}
+```

--- a/feedback/defensive-count-sol.Rmd
+++ b/feedback/defensive-count-sol.Rmd
@@ -1,0 +1,66 @@
+```{r, child = "defensive-count-ex.Rmd"}
+```
+
+----------------------------------------------------
+
+### Lösung:
+
+a)  
+
+Implizite Annahmen über `supposedly_a_count` von denen abhängt ob der 
+ursprünglichen Code das erwartete Verhalten hat:
+
+- `supposedly_a_count` ist was numerisches
+- `supposedly_a_count` hat Länge 1
+- `supposedly_a_count` ist nicht `NA` oder `NaN`
+- `supposedly_a_count` ist nicht negativ
+- `supposedly_a_count` ist nicht unendlich
+
+
+b)  
+
+Strenge Variante:
+```{r, eval = FALSE}
+count_them <- function(supposedly_a_count) {
+  checkmate::assert_number(supposedly_a_count,
+                           lower = 0, finite = TRUE,
+                           null.ok = FALSE, na.ok = FALSE
+  ) # defaults, not necessary
+  if (!checkmate::test_count(supposedly_a_count)) {
+    warning(
+      "rounding ", supposedly_a_count,
+      "to the nearest integer."
+    )
+    supposedly_a_count <- round(supposedly_a_count)
+  }
+  #always return an integer:
+  as.integer(supposedly_a_count)
+}  
+```
+
+Nachsichtigere Variante:
+```{r, eval = FALSE}
+count_them <- function(supposedly_a_count) {
+  if (length(supposedly_a_count) > 1) {
+    warning("only using first element of supposedly_a_count")
+    supposedly_a_count <- supposedly_a_count[1]
+  }
+  checkmate::assert_number(supposedly_a_count, finite = TRUE)
+  if (!checkmate::test_count(supposedly_a_count)) {
+    warning(
+      "rounding ", supposedly_a_count,
+      "to the nearest non-negative integer."
+    )
+    as.integer(max(0, round(supposedly_a_count)))
+  }
+}
+```
+
+Zu pragmatische Variante (ohne Warnungen, und die erste Zeile könnte schiefgehen...):
+```{r, eval = FALSE}
+count_them <- function(supposedly_a_count) {
+  supposedly_a_count <- round(as.numeric(supposedly_a_count[1]))
+  checkmate::assert_count(supposedly_a_count)
+  as.integer(supposedly_a_count)
+}  
+```

--- a/feedback/defensive-lag-sol.Rmd
+++ b/feedback/defensive-lag-sol.Rmd
@@ -1,0 +1,35 @@
+```{r, child = "defensive-lag-ex.Rmd"}
+```
+
+----------------------------------------------------
+### Lösung:
+
+Zum Beispiel:
+```{r, lag-def}
+# make a lagged version of x
+# inputs: x: a vector
+#         lag: how many lags?
+lag <- function(x, lag = 1L) {
+  checkmate::assert_atomic_vector(x, min.len = 1)
+  checkmate::assert_count(lag)
+  checkmate::assert_number(lag, upper = length(x))
+  c(rep(NA, lag), x[seq_len(length(x) - lag)])
+}
+```
+```{r, lag-test, error=TRUE}
+x <- seq_len(10)
+
+testthat::expect_equal(lag(x, 2), c(NA, NA, x[1:8]))
+testthat::expect_equal(lag(x, 0), x)
+testthat::expect_equal(lag(x, 10), rep(NA_integer_, 10))
+
+# these should all give errors that are triggered by input checks:
+testthat::expect_error(lag(list(1, 2)))
+testthat::expect_error(lag(matrix(1:2, 1, 2)))
+testthat::expect_error(lag(data.frame(1, 2)))
+
+testthat::expect_error(lag(x, 11))
+testthat::expect_error(lag(x, -1))
+testthat::expect_error(lag(x, c(1, 3)))
+testthat::expect_error(lag(x, .2))
+```


### PR DESCRIPTION
@Eleftheria1 

weiter so!   :2nd_place_medal: 


bitte bei `colmeans` auch nochmal Musterlösung vergleichen, s.u.
---------------------------------------------------------------------------------

*`lag`*, *`count`*:

:100: so geht's! 
In Zukunft dann bitte noch über *jede* (top-level) Funktion einen Kommentarblock mit Zweck, Inputs, Output der Funktion.

---------------------------------------------------------------------------------
*`colmeans`*:

gute bis sehr gute ansätze, aber im detail teilweise noch nicht ganz wie es muss. vgl. a. Musterlösung


- https://github.com/fort-w2021/defensive-ex-Eleftheria1/blob/cdf7e429b64c1238b9b1a7f07620d6761cb448ec/defensive-colmeans-ex.Rmd#L20-L21
korrekte idee: inputs homogen machen.  
problem hier: nicht jede liste lässt sich in dataframe umwandeln.  
könnte also schiefgehen, braucht also ein `try` und entsprechende Nachverarbeitung -- vgl Musterlösung 

- https://github.com/fort-w2021/defensive-ex-Eleftheria1/blob/cdf7e429b64c1238b9b1a7f07620d6761cb448ec/defensive-colmeans-ex.Rmd#L24-L25 
*early exit* identifiziert, sehr gut! :+1:

- https://github.com/fort-w2021/defensive-ex-Eleftheria1/blob/cdf7e429b64c1238b9b1a7f07620d6761cb448ec/defensive-colmeans-ex.Rmd#L31-L33 
mMn einfacher & simpler den check aus L. 24 zu streichen und nur den hier zu machen -- **KIS!** (anders gesagt: es reicht zu prüfen ob mehr als 0 numerische spalten vorhanden sind, ob noch  irgendwelche andere spalten da sind ist irrelevant für den output der funktion)

- https://github.com/fort-w2021/defensive-ex-Eleftheria1/blob/cdf7e429b64c1238b9b1a7f07620d6761cb448ec/defensive-colmeans-ex.Rmd#L36-L44
**KIS!**  -- ersetze ALLE diese Zeilen durch `numeric_cols <- df[, numeric, drop = FALSE]` 
  - sehr wichtiges allgemeines Pattern: `drop = FALSE` *immer* wenn wir aus arrays, matrizen, dataframes auswählen um automatisches type casting von R zu verhindern. 
  - fallunterscheidung ab l. 39 mMn völlig überflüssig. 


- https://github.com/fort-w2021/defensive-ex-Eleftheria1/blob/cdf7e429b64c1238b9b1a7f07620d6761cb448ec/defensive-colmeans-ex.Rmd#L40
BUG: `na.rm` wird hier fest auf TRUE gesetzt, sollte aber den Wert des übergebenen Arguments bekommen.